### PR TITLE
Add Swagger for API usage documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/kotlin/de/livepoll/api/config/RoutingConfig.kt
+++ b/src/main/kotlin/de/livepoll/api/config/RoutingConfig.kt
@@ -1,0 +1,15 @@
+package de.livepoll.api.config
+
+import io.swagger.annotations.ApiOperation
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import springfox.documentation.annotations.ApiIgnore
+
+@Controller
+@ApiIgnore
+class RoutingConfig {
+    @RequestMapping(method = [RequestMethod.GET], value = ["/"])
+    @ApiOperation(value = "Redirects the user to the swagger ui page", hidden = true)
+    fun swagger() = "redirect:/swagger-ui/index.html"
+}

--- a/src/main/kotlin/de/livepoll/api/config/SwaggerConfig.kt
+++ b/src/main/kotlin/de/livepoll/api/config/SwaggerConfig.kt
@@ -1,0 +1,45 @@
+package de.livepoll.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.ApiInfo
+import springfox.documentation.service.Contact
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger.web.UiConfigurationBuilder
+import javax.servlet.ServletContext
+
+@Configuration
+class SwaggerConfig {
+
+    // Variables as objects
+    private lateinit var context: ServletContext
+
+    @Bean
+    fun api() = Docket(DocumentationType.OAS_30)
+            .host("api.live-poll.de")
+            .enableUrlTemplating(true)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage("de.livepoll.api"))
+            .paths(PathSelectors.any())
+            .build()
+            .apiInfo(apiInfo())
+
+    @Bean
+    fun uiConfig() = UiConfigurationBuilder.builder()
+            .defaultModelsExpandDepth(-1)
+            .build()
+
+    private fun apiInfo() = ApiInfo(
+            "Live-Poll API",
+            "Platform for providing surveys with live display features",
+            "1.0.1",
+            "https://chillibits.com/pmapp?p=privacy",
+            Contact("ChilliBits", "https://www.chillibits.com", "contact@chillibits.com"),
+            "ODC DbCL v1.0 License",
+            "https://opendatacommons.org/licenses/dbcl/1.0/",
+            emptyList()
+    )
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,11 @@
+server.port = 8080
+server.http2.enabled = true
+server.compression.enabled = true
+server.compression.mime-types = text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml
+server.compression.min-response-size = 1024
+
+spring.application.name = "Live-Poll API"
+
 spring.datasource.url = ${LIVE_POLL_MYSQL_URL}
 spring.datasource.username = ${LIVE_POLL_MYSQL_USER}
 spring.datasource.password = ${LIVE_POLL_MYSQL_PASSWORD}


### PR DESCRIPTION
- Added Swagger to the project
- Added Swagger configuration file with all required data
- Added redirect from `/` to `/swagger-ui/index.html` to get to the Swagger documentation when requesting the root path