### PR TITLE
Feature/quiz item correct option

### DIFF
--- a/postman/Livepoll.postman_collection.json
+++ b/postman/Livepoll.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a3857427-e2b1-4190-90c9-664da2489dcd",
+		"_postman_id": "4348fa9f-7a6d-4190-b745-470d6a86d0ce",
 		"name": "Livepoll",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -438,7 +438,7 @@
 					"response": []
 				},
 				{
-					"name": "Create Quiz Item",
+					"name": "Create quiz item",
 					"event": [
 						{
 							"listen": "test",
@@ -457,7 +457,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"pollId\": \"{{poll-id}}\",\r\n    \"question\": \"postman-quiz-question\",\r\n    \"position\": 1,\r\n    \"answers\": [ { \"answer\" : \"postman-quiz-answer-1\", \"isCorrect\" : true}, { \"answer\" : \"postman-quiz-answer-2\", \"isCorrect\" : false}]\r\n}",
+							"raw": "{\r\n    \"pollId\": \"{{poll-id}}\",\r\n    \"position\": 1,\r\n    \"question\": \"postman-quiz-question\",\r\n    \"answers\": [ \"correct option\", \"wrong option\", \"wrong option\"]\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -473,6 +473,47 @@
 								"v1",
 								"poll-items",
 								"quiz"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create open text item",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"pollId\": \"{{poll-id}}\",\r\n    \"position\": 1,\r\n    \"question\": \"postman-open-text-question\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base-url}}/v1/poll-items/open-text",
+							"host": [
+								"{{base-url}}"
+							],
+							"path": [
+								"v1",
+								"poll-items",
+								"open-text"
 							]
 						}
 					},
@@ -1034,6 +1075,12 @@
 					""
 				]
 			}
+		}
+	],
+	"variable": [
+		{
+			"key": "base-url",
+			"value": "https://localhost:8080"
 		}
 	]
 }

--- a/src/main/kotlin/de/livepoll/api/entity/dto/OpenTextItemDtoIn.kt
+++ b/src/main/kotlin/de/livepoll/api/entity/dto/OpenTextItemDtoIn.kt
@@ -2,6 +2,6 @@ package de.livepoll.api.entity.dto
 
 data class OpenTextItemDtoIn(
     val pollId: Long,
+    val position: Int,
     val question: String,
-    val position: Int
 )

--- a/src/main/kotlin/de/livepoll/api/entity/dto/QuizItemDtoIn.kt
+++ b/src/main/kotlin/de/livepoll/api/entity/dto/QuizItemDtoIn.kt
@@ -2,12 +2,7 @@ package de.livepoll.api.entity.dto
 
 class QuizItemDtoIn(
     var pollId: Long,
-    val question: String,
     val position: Int,
-    val answers: List<QuizItemAnswerDtoIn>
-)
-
-class QuizItemAnswerDtoIn(
-    val answer: String,
-    val isCorrect: Boolean
+    val question: String,
+    val answers: List<String>
 )

--- a/src/main/kotlin/de/livepoll/api/service/PollItemService.kt
+++ b/src/main/kotlin/de/livepoll/api/service/PollItemService.kt
@@ -32,6 +32,7 @@ class PollItemService {
     @Autowired
     private lateinit var quizItemAnswerRepository: QuizItemAnswerRepository
 
+
     //--------------------------------------------- Get ----------------------------------------------------------------
 
     fun getPollItem(pollItemId: Long): PollItemDtoOut {
@@ -60,6 +61,7 @@ class PollItemService {
     fun deleteItem(itemId: Long) {
         pollItemRepository.deleteById(itemId)
     }
+
 
     //-------------------------------------------- Create --------------------------------------------------------------
 
@@ -107,8 +109,10 @@ class PollItemService {
                     mutableListOf()
                 )
                 // Quiz item answers
-                quizItem.answers =
-                    item.answers.map { QuizItemAnswer(0, quizItem, it.answer, it.isCorrect, 0) }.toMutableList()
+                quizItem.answers = item.answers.mapIndexed { index, element ->
+                    QuizItemAnswer(0, quizItem, element, index == 0,  0)
+                }.toMutableList()
+
                 quizItemRepository.saveAndFlush(quizItem)
                 quizItem.answers.forEach { quizItemAnswerRepository.saveAndFlush(it) }
                 return quizItem.toDtoOut()


### PR DESCRIPTION
When creating a new quiz item using the post endpoint `/v1/poll-items/quiz`, the first answer is now automatically considered as the correct one.

|:warning: | @marcauberer this is slightly affecting the API |
|----------|:-------------------------------|


The body now looks like this:

```
{
    "pollId": "{{poll-id}}",
    "position": 1,
    "question": "postman-quiz-question",
    "answers": [ "correct option", "wrong option", "wrong option"]
}
```

Also added "Create open text item" to the Postman collection.
