### PR TITLE
Show error messages locally and in GitHub tests

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       LIVE_POLL_HTTPS_ENABLED: "true"
       LIVE_POLL_HTTPS_CERT_PASSWORD: ${LIVE_POLL_HTTPS_CERT_PASSWORD}
       LIVE_POLL_POSTMAN: "true"
+      server.error.include-message: "always"
     depends_on:
       db:
         condition: service_healthy

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml
     min-response-size: 1024
+  error:
+    # https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties-server
+    # https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#changes-to-the-default-error-pages-content
+    include-message: on-param
+    include-binding-errors: always
+    include-stacktrace: NEVER
 
 spring:
   application.name: Live-Poll API


### PR DESCRIPTION
@livepoll/core-team  If you want to see the error messages locally (e.g. using Postman), you should include this env variable to IntelliJ:

`server.error.include-message`: `always`