### PR TITLE
Add poll name to websocket poll items

### DIFF
--- a/postman/Livepoll.postman_collection.json
+++ b/postman/Livepoll.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b83df12e-5482-4bc6-baa9-c95b38afdbb2",
+		"_postman_id": "7d758c5d-b8c3-450b-9405-89fcdb602496",
 		"name": "Livepoll",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1378,7 +1378,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{$randomProductName}}\",\r\n    \"startDate\": \"1669892400000\",\r\n    \"endDate\":\"1669892400000\",\r\n    \"slug\": \"12345\",\r\n    \"currentItem\": \"{{poll-item-id}}\"\r\n}",
+							"raw": "{\r\n    \"name\": \"{{$randomProductName}}\",\r\n    \"startDate\": \"1669892400000\",\r\n    \"endDate\":\"1669892400000\",\r\n    \"slug\": \"{{$randomInt}}\",\r\n    \"currentItem\": \"{{poll-item-id}}\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2199,8 +2199,8 @@
 									"            headers: 'Cookie:'+pm.environment.get(\"cookies\")\r",
 									"        }, function(error, response) {\r",
 									"    pm.test(\"Poll item does not exist anymore\", function() {\r",
-									"        pm.expect(response).to.have.property('code', 404)\r",
-									"        pm.expect(response).to.have.property('status', 'Not Found')\r",
+									"        pm.expect(response).to.have.property('code', 403)\r",
+									"        pm.expect(response).to.have.property('status', 'Forbidden')\r",
 									"    })\r",
 									"})\r",
 									"\r",

--- a/src/main/kotlin/de/livepoll/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/de/livepoll/api/config/SecurityConfig.kt
@@ -27,7 +27,6 @@ class SecurityConfig(
             .antMatchers("/v1/account/register").permitAll()
             .antMatchers("/v1/account/confirm").permitAll()
             .antMatchers("/v1/account/login").permitAll()
-            .antMatchers("/v1/polls/{id:[\\d]+}").permitAll()
             .antMatchers("/v1/websocket/**").permitAll()
             .antMatchers("/actuator/**").permitAll()
             //.antMatchers("/admin").hasRole("ADMIN") // TODO: introduce ROLE_ADMIN authority later on

--- a/src/main/kotlin/de/livepoll/api/controller/PollController.kt
+++ b/src/main/kotlin/de/livepoll/api/controller/PollController.kt
@@ -37,6 +37,7 @@ class PollController(
     @ApiOperation(value = "Get poll", tags = ["Poll"])
     @GetMapping("/{id}")
     fun getPoll(@PathVariable(name = "id") pollId: Long): PollDtoOut {
+        accountService.checkAuthorizationByPollId(pollId)
         return pollService.getPoll(pollId)
     }
 

--- a/src/main/kotlin/de/livepoll/api/entity/dto/PollItemWithPollNameDtoOut.kt
+++ b/src/main/kotlin/de/livepoll/api/entity/dto/PollItemWithPollNameDtoOut.kt
@@ -1,0 +1,10 @@
+package de.livepoll.api.entity.dto
+
+class PollItemWithPollNameDtoOut(
+        val itemId: Long,
+        val pollId: Long,
+        val question: String,
+        val position: Int,
+        val type: String,
+        val pollName: String
+)

--- a/src/main/kotlin/de/livepoll/api/util/CustomModelMapper.kt
+++ b/src/main/kotlin/de/livepoll/api/util/CustomModelMapper.kt
@@ -71,3 +71,7 @@ fun OpenTextItemAnswer.toDtoOut(): OpenTextItemAnswerDtoOut {
 fun OpenTextItemParticipantAnswerDtoIn.toDbEntity(item: OpenTextItem): OpenTextItemAnswer {
     return OpenTextItemAnswer(0, item, this.answer)
 }
+
+fun PollItemDtoOut.toPollItemWithPollName(pollName: String): PollItemWithPollNameDtoOut {
+    return PollItemWithPollNameDtoOut(this.itemId, this.pollId, this.question, this.position, this.type, pollName)
+}

--- a/src/main/kotlin/de/livepoll/api/util/websocket/SubscribeListener.kt
+++ b/src/main/kotlin/de/livepoll/api/util/websocket/SubscribeListener.kt
@@ -3,6 +3,7 @@ package de.livepoll.api.util.websocket
 import de.livepoll.api.repository.PollRepository
 import de.livepoll.api.service.PollItemService
 import de.livepoll.api.service.WebSocketService
+import de.livepoll.api.util.toPollItemWithPollName
 import org.springframework.context.ApplicationListener
 import org.springframework.http.HttpStatus
 import org.springframework.messaging.simp.SimpMessageSendingOperations
@@ -34,8 +35,8 @@ class SubscribeListener(
                     messagingTemplate.convertAndSendToUser(event.user!!.name, url, "{\"pollId\":${poll.id}}")
                     throw ResponseStatusException(HttpStatus.NOT_FOUND)
                 } else {
-                    val pollItemDto = pollItemService.getPollItem(poll.currentItem!!)
-                    messagingTemplate.convertAndSendToUser(event.user!!.name, url, pollItemDto)
+                    val pollItemOut = pollItemService.getPollItem(poll.currentItem!!).toPollItemWithPollName(poll.name)
+                    messagingTemplate.convertAndSendToUser(event.user!!.name, url, pollItemOut)
                 }
             }
         } else if (destination.contains("presentation")) {


### PR DESCRIPTION
The authorization for the poll endpoint was added again and the poll name is now sent with the poll item when it is sent via the web socket. Because of that adjustments in the frontend are also necessary.